### PR TITLE
Add dockerfile and docker-compose config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:latest
+RUN : \
+    && apt-get -y update \
+    && apt-get -y install git \
+    && git clone https://github.com/facebook/infer.git \
+    && apt-get install  ca-certificates \
+    && apt-get install -y  curl \
+    && apt-get install -y gnupg \
+    && apt-get install -y lsb-release \
+    && apt-get install -y software-properties-common \
+    && echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get install -y opam \
+    && add-apt-repository ppa:deadsnakes/ppa -y 
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install python3.8 -y 
+RUN : \
+    && apt-get install -y pkg-config \
+    && apt install -y default-jdk \
+    && apt install -y default-jre \
+    && VERSION=1.1.0; \
+        curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
+        | tar -C /opt -xJ && \
+        ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer

--- a/docker/data/README.md
+++ b/docker/data/README.md
@@ -1,0 +1,3 @@
+This directory is shared with the docker-compose service `fixer`, meaning it can access the contents in a 'simulated' directory `data`.
+
+Any files put here (including this one) can be accessed by the service, and outputs can be put here by it. It serves as a sort of 'communication hub'.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  fixer:
+    build: .
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
Add a `Dockerfile` and `docker-compose.yml`, both in the `docker` directory, which are used to set up a docker-compose service called `fixer`, in which `infer` can be used.

Also add a directory `docker/data/`, which can be accessed from within the `fixer` service.

Running this service with a command-line interface can be done using `sudo docker-compose run fixer` (using `exit` to quit the service again).